### PR TITLE
Update Soln7_03.cpp

### DIFF
--- a/Beginning C++ 17 source code/Exercises/Chapter 07/Soln7_03.cpp
+++ b/Beginning C++ 17 source code/Exercises/Chapter 07/Soln7_03.cpp
@@ -15,7 +15,7 @@ int main()
   std::cout << "\nEnter the word to be replaced: ";
   std::cin >> word;
   
-  std::string lower_word{word};                              // Convert word to lower case
+  std::string lower_word;                                    // Convert word to lower case
   for (auto ch : word)                                       // (we do so once, rather than with every iteration of the loop)
     lower_word += std::tolower(ch);
 


### PR DESCRIPTION
lower_word was actually a concatenation of the string word and the string word in lower case, leading to wrong result when the search word contained capital letters.